### PR TITLE
fix: avatar display size

### DIFF
--- a/_pages/index/submission-card.js
+++ b/_pages/index/submission-card.js
@@ -73,7 +73,7 @@ export default function SubmissionCard({ submission, contract }) {
         }
         mainSx={{ flexDirection: "column" }}
       >
-        <Image variant="avatar" src={evidence?.file?.photo} />
+        <Image variant="avatar" src={evidence?.file?.photo} sx={{ objectFit: "cover" }} />
         <Text
           sx={{
             fontSize: 1,

--- a/_pages/profile/[id]/submission-details-card/index.js
+++ b/_pages/profile/[id]/submission-details-card/index.js
@@ -275,7 +275,7 @@ export default function SubmissionDetailsCard({
         }}
       >
         <Image
-          sx={{ objectFit: "contain" }}
+          sx={{ objectFit: "cover" }}
           variant="avatar"
           src={evidence?.file?.photo}
         />


### PR DESCRIPTION
Currently avatars are being crop and display incorrectly, this small fix address this issue by changing the objectFit property to `cover`.